### PR TITLE
Force source in mvn config

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -60,6 +60,15 @@
 		<finalName>bouquet-auth</finalName>
 		<plugins>
 			<plugin>
+			    <groupId>org.apache.maven.plugins</groupId>
+			    <artifactId>maven-compiler-plugin</artifactId>
+			    <version>3.0</version>
+			    <configuration>
+				<source>1.7</source>
+				<target>1.7</target>
+			    </configuration>
+			</plugin>
+			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-war-plugin</artifactId>
 				<version>2.4</version>


### PR DESCRIPTION
A default maven installation might not be able to compile without this specific configuration.